### PR TITLE
Removing call to CheckIndex()

### DIFF
--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -9,7 +9,7 @@
 #define CLIENT_VERSION_MAJOR       1
 #define CLIENT_VERSION_MINOR       1
 #define CLIENT_VERSION_REVISION    3
-#define CLIENT_VERSION_BUILD       0
+#define CLIENT_VERSION_BUILD       11
 
 // Set to true for release, false for prerelease or test build
 #define CLIENT_VERSION_IS_RELEASE  true

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -227,10 +227,11 @@ bool CBlockTreeDB::LoadBlockIndexGuts()
                 if (pindexGenesisBlock == NULL && diskindex.GetBlockHash() == Params().HashGenesisBlock())
                     pindexGenesisBlock = pindexNew;
 
-                if (!pindexNew->CheckIndex())
-                    return error("LoadBlockIndex() : CheckIndex failed: %s", pindexNew->ToString().c_str());
+//                if (!pindexNew->CheckIndex())
+//                    return error("LoadBlockIndex() : CheckIndex failed: %s", pindexNew->ToString().c_str());
 
                 pcursor->Next();
+		assert(pcursor->Valid());
             } else {
                 break; // if shutdown requested or finished loading block index
             }


### PR DESCRIPTION
Hi Xedoscoin owners, 
I propose to remove unneeded for me call to CheckIndex() which prevent the chain for syncinng after AuxPow implementation. 
Please for your review.